### PR TITLE
Only apply spyOn() to xhr object when the object is not already spied upon (necessary for running under JSTestDriver)

### DIFF
--- a/lib/spec-helper.js
+++ b/lib/spec-helper.js
@@ -1,7 +1,7 @@
 beforeEach(function() {
 
   if (typeof jQuery != 'undefined') {
-    spyOn(jQuery.ajaxSettings, 'xhr').andCallFake(function() {
+    spyOn(jQuery.ajaxSettings, 'xhr', true).andCallFake(function() {
       var newXhr = new FakeXMLHttpRequest();
       ajaxRequests.push(newXhr);
       return newXhr;
@@ -9,7 +9,7 @@ beforeEach(function() {
   }
 
   if (typeof Prototype != 'undefined') {
-    spyOn(Ajax, "getTransport").andCallFake(function() {
+    spyOn(Ajax, "getTransport", true).andCallFake(function() {
       return new FakeXMLHttpRequest();
     });
   }


### PR DESCRIPTION
I'm running JSTestDriver via the jasmine-jstd-adapter, and using jasmine-ajax to mock HTTP responses.
This works fine when running through "rake jasmine:ci" (selenium) and direct HTML execution, but fails in JSTestDriver (`Error: xhr has already been spied upon`). This might well be a problem in how the jstd adapter, but is a simple fix in the ajax lib: Simpy check that the xhr() method hasn't already been spied upon.

This is a bit fragile because the ajax lib silently fail if xhr() was spied on by another library, but thats unlikely right? Is there a way to identify which callback is spying on a method? I can't compare the original spy (before running beforeEach() in spec-helper.js) with the return value of spyOn(), as it creates a new spy each time.

Note: This requires a patch to jasmine.js for allowing spyOn() to pass this parameter through: https://github.com/pivotal/jasmine/pull/74

The actual breaking code is in the SilverStripe CMS project (TreeDropdownField.js), see:
https://github.com/silverstripe/sapphire/tree/jstree/tests/javascript

My jstestdriver.confg:

```
server: http://localhost:9876

load:
  - ../../thirdparty/jasmine/lib/jasmine.js
  - ../../thirdparty/jasmine/lib/jasmine-html.js
  - ../../thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js
  - ../../thirdparty/jasmine-jquery/lib/jasmine-jquery.js
  - ../../thirdparty/jasmine-dom/lib/jasmine-dom-fixtures.js
  - ../../thirdparty/jasmine-ajax/lib/mock-ajax.js
  - ../../thirdparty/jasmine-ajax/lib/spec-helper.js
  - ../../thirdparty/jquery/jquery.js
  - ../../thirdparty/jquery-entwine/dist/*
  - ../../thirdparty/jstree/jquery.jstree.js
  - ../../javascript/TreeDropdownField.js
  - TreeDropdownField/TreeDropdownField.js
```

The error: 

```
Error: xhr has already been spied upon
          at [object Object].spyOn (http://localhost:9876/test/_/_/thirdparty/jasmine/lib/jasmine.js:2062:11)
          at http://localhost:9876/test/_/_/thirdparty/jasmine/lib/jasmine.js:444:39
          at [object Object].<anonymous> (http://localhost:9876/test/_/_/thirdparty/jasmine-ajax/lib/spec-helper.js:4:5)
          at [object Object].<anonymous> (http://localhost:9876/test/_/_/thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js:26:61)
          at [object Object].<anonymous> (http://localhost:9876/test/_/_/thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js:25:33)
          at [object Object].<anonymous> (http://localhost:9876/test/_/_/thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js:25:33)
          at [object Object].<anonymous> (http://localhost:9876/test/_/_/thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js:25:33)
          at [object Object].test that it it sets the selected titles (http://localhost:9876/test/_/_/thirdparty/jasmine-jstd-adapter/src/JasmineAdapter.js:55:19)
```
