### PR TITLE
Fix get all response headers

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -81,6 +81,14 @@ function FakeXMLHttpRequest() {
       return xhr.responseHeaders[name];
     },
 
+    getAllResponseHeaders: function () {
+      var ret = "";
+      for (var i in xhr.responseHeaders) {
+        ret += i+ " : "+xhr.responseHeaders[i] + "\r\n";
+      }
+      return ret;
+    },
+
     responseText: null,
 
     response: function(response) {


### PR DESCRIPTION
I've got problems to use this great mock with jquery 1.5. 
I figured out, that i should have to do something with the missing getAllResponseHeaders method.

So i added one. I think the next thing, have to be done is to filter "Set-Cookie" and "Set-Cookie2" out of the headers - like seen in the w3-spec.
