### PR TITLE
Remove the single remaining dependency on the global $

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -48,7 +48,7 @@ function clearAjaxRequests() {
 
 // Fake XHR for mocking Ajax Requests & Responses
 function FakeXMLHttpRequest() {
-  var extend = Object.extend || $.extend;
+  var extend = Object.extend || jQuery.extend;
   extend(this, {
     requestHeaders: {},
 


### PR DESCRIPTION
Direct reference to window.jQuery is used everywhere else.  This gives trouble when running with $.noConflict();

Ran the tests, they pass, as expected.
