### PR TITLE
return request body params in a consistent and usable way

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -84,7 +84,7 @@ function FakeXMLHttpRequest() {
       var params = this.params.split('&');
 
       for (var i = 0; i < params.length; ++i) {
-        var kv = params[i].split('=');
+        var kv = params[i].replace(/\+/g, ' ').split('=');
         var key = decodeURIComponent(kv[0]);
         data[key] = data[key] || [];
         data[key].push(decodeURIComponent(kv[1]));

--- a/spec/javascripts/fake-xml-http-request-spec.js
+++ b/spec/javascripts/fake-xml-http-request-spec.js
@@ -46,15 +46,15 @@ describe("FakeXMLHttpRequest", function() {
   describe("data", function() {
     beforeEach(function() {
       xhr.open("POST", "http://example.com?this=that")
-      xhr.send('stooges=shemp&stooges=larry%20%26%20moe%20%26%20curly&some%3Dthing=else')
+      xhr.send('3+stooges=shemp&3+stooges=larry%20%26%20moe%20%26%20curly&some%3Dthing=else+entirely')
     });
 
     it("should return request params as a hash of arrays with values sorted alphabetically", function() {
       var data = xhr.data();
-      expect(data['stooges'].length).toEqual(2);
-      expect(data['stooges'][0]).toEqual('larry & moe & curly');
-      expect(data['stooges'][1]).toEqual('shemp');
-      expect(data['some=thing']).toEqual(['else']);
+      expect(data['3 stooges'].length).toEqual(2);
+      expect(data['3 stooges'][0]).toEqual('larry & moe & curly');
+      expect(data['3 stooges'][1]).toEqual('shemp');
+      expect(data['some=thing']).toEqual(['else entirely']);
     });
   });
 });


### PR DESCRIPTION
Helper method to avoid having to parse and decode request body parameters when making assertions on the format of the request.
