### PR TITLE
jQuery 2.0 renamed onreadystatechange to onload.

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -70,6 +70,9 @@ function FakeXMLHttpRequest() {
 
     readyState: 0,
 
+    onload: function() {
+    },
+
     onreadystatechange: function(isTimeout) {
     },
 
@@ -120,6 +123,7 @@ function FakeXMLHttpRequest() {
       // uncomment for jquery 1.3.x support
       // jasmine.Clock.tick(20);
 
+      this.onload();
       this.onreadystatechange();
     },
     responseTimeout: function() {


### PR DESCRIPTION
In jQuery 2.0 the onreadystatechange method has been dropped in favour of onload, so for compatibility with the upcoming 2.0 and with previous versions of jQuery we should mock both calls accordingly.
