### PR TITLE
Add README example for testing request parameters.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -130,6 +130,9 @@ Putting it all together, you can install the mock, pass some spies as callbacks 
         });
 
         request = mostRecentAjaxRequest();
+        expect(request.url).toBe('venues/search');
+        expect(request.method').toBe('POST');
+        expect(request.data()).toEqual({latLng: ['40.019461, -105.273296']});
       });
 
       describe("on success", function() {


### PR DESCRIPTION
Same as before. Why would you _post_ to a search? Dunno, but you did (maybe same reason you'd pass a lat, lng string vs structured args. ;) ). 
