### PR TITLE
Include textual portion of HTTP status in response object

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -116,7 +116,7 @@ function FakeXMLHttpRequest() {
 
     response: function(response) {
       this.status = response.status;
-      this.statusText = response.statusText;
+      this.statusText = response.statusText || "";
       this.responseText = response.responseText || "";
       this.readyState = 4;
       this.responseHeaders = response.responseHeaders ||


### PR DESCRIPTION
I needed to be able to assert that a callback function was invoked with the HTTP status of a failing AJAX request. Currently one can only set the status number of the HTTP status, not the text (which is passed into the error callback via errorThrown). 

This change allows the HTTP status text of the response to be mocked by the tester.
