### PR TITLE
Add ajaxRequestsTo method

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -1,5 +1,6 @@
 pairs:
   hg: Hunter Gillane
+  km: Ken Mayer
 
 email:
   prefix: pair

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'rake'
 gem 'jasmine', "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.3.2)
     childprocess (0.3.6)

--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -42,6 +42,19 @@ function mostRecentAjaxRequest() {
   }
 }
 
+function ajaxRequestsTo(url_to_match) {
+  if (ajaxRequests.length == 0) return [];
+  var matching_requests = [];
+
+  for (var i = 0; i < ajaxRequests.length; i++) {
+    if (ajaxRequests[i].url == url_to_match) {
+      matching_requests.push(ajaxRequests[i]);
+    }
+  }
+
+  return matching_requests;
+}
+
 function clearAjaxRequests() {
   ajaxRequests = [];
 }

--- a/spec/javascripts/mock-ajax-jquery-spec.js
+++ b/spec/javascripts/mock-ajax-jquery-spec.js
@@ -92,6 +92,35 @@ describe("Jasmine Mock Ajax (for jQuery)", function() {
       });
     });
 
+    describe("ajaxRequestsTo", function () {
+      describe("when there are no matching requests", function() {
+        it("should return []", function() {
+          expect(ajaxRequestsTo('example.com/someOtherApi')).toEqual([]);
+        })
+      });
+
+      describe("when there is one matching request", function() {
+        it("should return array with the matching request", function() {
+          expect(ajaxRequestsTo('example.com/someApi').length).toEqual(1);
+        })
+      });
+
+      describe("when there is a non-matching request", function() {
+        beforeEach(function() {
+          jQuery.ajax({
+            url: "example.com/someOtherApi",
+            type: "GET",
+            success: success,
+            complete: complete,
+            error: error
+          });
+        });
+        it("should return just the matching requests", function() {
+          expect(ajaxRequestsTo('example.com/someApi').length).toEqual(1);
+        })
+      })
+    });
+
     describe("clearAjaxRequests()", function () {
       beforeEach(function() {
         clearAjaxRequests();


### PR DESCRIPTION
- Will search ajaxRequests for a url_to_match, returns all matching
  request objects. Useful for saying,
  expect(ajaxRequestsTo('some/api').length)).toEqual(1) when you might
  have many asynchronous calls happening and you're not sure or don't
  care about the order of the ajax requests.
