### PR TITLE
Create requestHeaders object in FakeXMLHttpRequest constructor 

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -98,12 +98,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function fakeRequest(requestTracker, stubTracker) {
     function FakeXMLHttpRequest() {
       requestTracker.track(this);
+      this.requestHeaders = {};
     }
 
     extend(FakeXMLHttpRequest.prototype, window.XMLHttpRequest);
     extend(FakeXMLHttpRequest.prototype, {
-      requestHeaders: {},
-
       open: function() {
         this.method = arguments[0];
         this.url = arguments[1];

--- a/spec/javascripts/fake-xml-http-request-spec.js
+++ b/spec/javascripts/fake-xml-http-request-spec.js
@@ -1,15 +1,44 @@
 describe("FakeXMLHttpRequest", function() {
   var xhr;
+  var xhr2;
   beforeEach(function() {
     var realXMLHttpRequest = jasmine.createSpy('realRequest'),
         fakeGlobal = {XMLHttpRequest: realXMLHttpRequest},
         mockAjax = new MockAjax(fakeGlobal);
     mockAjax.install();
     xhr = new fakeGlobal.XMLHttpRequest();
+    xhr2 = new fakeGlobal.XMLHttpRequest();
   });
 
   it("should have an initial readyState of 0 (uninitialized)", function() {
     expect(xhr.readyState).toEqual(0);
+  });
+
+  describe("when setting request headers", function() {
+    beforeEach(function() {
+      xhr.setRequestHeader('X-Header-1', 'one');
+    });
+
+    it("should make the request headers available", function() {
+      expect(Object.keys(xhr.requestHeaders).length).toEqual(1);
+      expect(xhr.requestHeaders['X-Header-1']).toEqual('one');
+    });
+
+    describe("when setting headers on another xhr object", function() {
+      beforeEach(function() {
+        xhr2.setRequestHeader('X-Header-2', 'two');
+      });
+
+      it("should make the only its request headers available", function() {
+        expect(Object.keys(xhr2.requestHeaders).length).toEqual(1);
+        expect(xhr2.requestHeaders['X-Header-2']).toEqual('two');
+      });
+
+      it("should not modify any other xhr objects", function() {
+        expect(Object.keys(xhr.requestHeaders).length).toEqual(1);
+        expect(xhr.requestHeaders['X-Header-1']).toEqual('one');
+      });
+    });
   });
 
   describe("when opened", function() {


### PR DESCRIPTION
All FakeXMLHttpRequest objects were sharing a single requestHeaders hash that was set on the FakeXMLHttpRequest prototype.  This caused request headers to bleed between tests.  Create a new requestHeaders hash for each object in the constructor instead.
