### PR TITLE
fix the prototype chain of the FakeXMLHttpRequest object

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -101,7 +101,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       this.requestHeaders = {};
     }
 
-    extend(FakeXMLHttpRequest.prototype, window.XMLHttpRequest);
+    extend(FakeXMLHttpRequest.prototype, new window.XMLHttpRequest());
     extend(FakeXMLHttpRequest.prototype, {
       open: function() {
         this.method = arguments[0];

--- a/spec/javascripts/fake-xml-http-request-spec.js
+++ b/spec/javascripts/fake-xml-http-request-spec.js
@@ -2,8 +2,9 @@ describe("FakeXMLHttpRequest", function() {
   var xhr;
   var xhr2;
   beforeEach(function() {
-    var realXMLHttpRequest = jasmine.createSpy('realRequest'),
-        fakeGlobal = {XMLHttpRequest: realXMLHttpRequest},
+    var realXMLHttpRequest = {someOtherProperty: 'someValue'},
+        realXMLHttpRequestCtor = spyOn(window, 'XMLHttpRequest').and.returnValue(realXMLHttpRequest),
+        fakeGlobal = {XMLHttpRequest: realXMLHttpRequestCtor},
         mockAjax = new MockAjax(fakeGlobal);
     mockAjax.install();
     xhr = new fakeGlobal.XMLHttpRequest();
@@ -118,4 +119,10 @@ describe("FakeXMLHttpRequest", function() {
       expect(data['some=thing']).toEqual(['else entirely']);
     });
   });
+
+  describe("when a fake XMLHttpRequest is created", function() {
+    it("inherits the properties of the real XMLHttpRequest object", function() {
+      expect(xhr.someOtherProperty).toBe('someValue');
+    })
+  })
 });

--- a/spec/javascripts/with-mock-spec.js
+++ b/spec/javascripts/with-mock-spec.js
@@ -7,22 +7,24 @@ describe("withMock", function() {
   };
 
   it("installs the mock for passed in function, and uninstalls when complete", function() {
-    var xmlHttpRequest = spyOn(window, 'XMLHttpRequest').and.returnValue({open: function() {}, send: function() {}}),
-      fakeGlobal = {XMLHttpRequest: xmlHttpRequest},
+    var xmlHttpRequest = jasmine.createSpyObj('XMLHttpRequest', ['open', 'send']),
+      xmlHttpRequestCtor = spyOn(window, 'XMLHttpRequest').and.returnValue(xmlHttpRequest),
+      fakeGlobal = {XMLHttpRequest: xmlHttpRequestCtor},
       mockAjax = new MockAjax(fakeGlobal);
 
     mockAjax.withMock(function() {
       sendRequest(fakeGlobal);
-      expect(xmlHttpRequest).not.toHaveBeenCalled();
+      expect(xmlHttpRequest.open).not.toHaveBeenCalled();
     });
 
     sendRequest(fakeGlobal);
-    expect(xmlHttpRequest).toHaveBeenCalled();
+    expect(xmlHttpRequest.open).toHaveBeenCalled();
   });
 
   it("properly uninstalls when the passed in function throws", function() {
-    var xmlHttpRequest = spyOn(window, 'XMLHttpRequest').and.returnValue({open: function() {}, send: function() {}}),
-      fakeGlobal = {XMLHttpRequest: xmlHttpRequest},
+    var xmlHttpRequest = jasmine.createSpyObj('XMLHttpRequest', ['open', 'send']),
+      xmlHttpRequestCtor = spyOn(window, 'XMLHttpRequest').and.returnValue(xmlHttpRequest),
+      fakeGlobal = {XMLHttpRequest: xmlHttpRequestCtor},
       mockAjax = new MockAjax(fakeGlobal);
 
     expect(function() {
@@ -32,6 +34,6 @@ describe("withMock", function() {
     }).toThrow("error");
 
     sendRequest(fakeGlobal);
-    expect(xmlHttpRequest).toHaveBeenCalled();
+    expect(xmlHttpRequest.open).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
the prototype of the FakeXMLHttpRequest object will now be an XMLHttpRequest object, including properties such as 'withCredentials', not the XMLHttpRequest constructor function
