### PR TITLE
Add test to see if responseText is a function

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -178,7 +178,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       response: function(response) {
         this.status = response.status;
         this.statusText = response.statusText || "";
-        this.responseText = response.responseText || "";
+        if (Object.prototype.toString.call(response.responseText) == "[object Function]") {
+            this.responseText = response.responseText(this.params);
+        } else {
+            this.responseText = response.responseText || "";
+        } 
         this.readyState = 4;
         this.responseHeaders = response.responseHeaders ||
           {"Content-type": response.contentType || "application/json" };


### PR DESCRIPTION
This request allows users to specify responseText as a function rather than static text. I believe this will address the request in issue #36 without impacting any other functionality.
