### PR TITLE
Response header content-type should be lowercase

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -50,6 +50,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     return false;
   }
 
+  function FakeDOMException(name, code, message) {
+    this.name = name;
+    this.code = code;
+    this.message = message;
+  }
+
+
   function MockAjax(global) {
     var requestTracker = new RequestTracker(),
       stubTracker = new StubTracker(),
@@ -126,7 +133,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       },
 
       setRequestHeader: function(header, value) {
+        if (this.readyState !== 1) {
+          var msg = "Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.";
+          throw new FakeDOMException('InvalidStateError', 11, msg);
+        }
         this.requestHeaders[header.toLowerCase()] = value;
+      },
+
+      _getRequestHeader: function(header) {
+        if (this.readyState !== 1) {
+          throw new Error("Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.");
+        }
+
+        return this.requestHeaders[header.toLowerCase()];
       },
 
       abort: function() {
@@ -240,7 +259,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     this.filter = function(url_to_match) {
-      if (requests.length == 0) return [];
+      if (requests.length === 0) return [];
       var matching_requests = [];
 
       for (var i = 0; i < requests.length; i++) {

--- a/spec/javascripts/fake-xml-http-request-spec.js
+++ b/spec/javascripts/fake-xml-http-request-spec.js
@@ -12,8 +12,8 @@ describe("FakeXMLHttpRequest", function() {
   });
 
   function objectKeys(obj) {
-    keys = [];
-    for (key in obj) {
+    var keys = [];
+    for (var key in obj) {
       if (obj.hasOwnProperty(key)) {
         keys.push(key);
       }
@@ -26,29 +26,35 @@ describe("FakeXMLHttpRequest", function() {
     expect(xhr.readyState).toEqual(0);
   });
 
+  it("should throw if attempt to set a header", function() {
+    expect(function() { xhr.setRequestHeader('X-Header-1', 'one'); }).toThrow();
+  });
+
   describe("when setting request headers", function() {
     beforeEach(function() {
+      xhr.open("GET", "http://example.com");
       xhr.setRequestHeader('X-Header-1', 'one');
     });
 
     it("should make the request headers available", function() {
       expect(objectKeys(xhr.requestHeaders).length).toEqual(1);
-      expect(xhr.requestHeaders['X-Header-1']).toEqual('one');
+      expect(xhr._getRequestHeader('X-Header-1')).toEqual('one');
     });
 
     describe("when setting headers on another xhr object", function() {
       beforeEach(function() {
+        xhr2.open("GET", "http://example2.com");
         xhr2.setRequestHeader('X-Header-2', 'two');
       });
 
       it("should make the only its request headers available", function() {
         expect(objectKeys(xhr2.requestHeaders).length).toEqual(1);
-        expect(xhr2.requestHeaders['X-Header-2']).toEqual('two');
+        expect(xhr2._getRequestHeader('X-Header-2')).toEqual('two');
       });
 
       it("should not modify any other xhr objects", function() {
         expect(objectKeys(xhr.requestHeaders).length).toEqual(1);
-        expect(xhr.requestHeaders['X-Header-1']).toEqual('one');
+        expect(xhr._getRequestHeader('X-Header-1')).toEqual('one');
       });
     });
   });

--- a/spec/javascripts/mock-ajax-toplevel-spec.js
+++ b/spec/javascripts/mock-ajax-toplevel-spec.js
@@ -18,7 +18,7 @@ describe("Jasmine Mock Ajax (for toplevel)", function() {
     onreadystatechange = function() {
       if (this.readyState == (this.DONE || 4)) { // IE 8 doesn't support DONE
         if (this.status == 200) {
-          if (this.responseHeaders['Content-type'] === 'application/json') {
+          if (this.getResponseHeader('Content-type') === 'application/json') {
             this.response = JSON.parse(this.responseText);
           } else {
             this.response = this.responseText;

--- a/spec/javascripts/webmock-style-spec.js
+++ b/spec/javascripts/webmock-style-spec.js
@@ -37,7 +37,7 @@ describe("Webmock style mocking", function() {
 
   it("should set the contentType", function() {
     sendRequest(fakeGlobal);
-    expect(response.responseHeaders['Content-type']).toEqual('application/json');
+    expect(response.getResponseHeader('Content-type')).toEqual('application/json');
   });
 
   it("should set the responseText", function() {


### PR DESCRIPTION
The current initial caps header ('Content-type') is inconsistent with webkit and breaks superagent
