### PR TITLE
Allow stubs to use Regex

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -100,6 +100,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     this.findStub = function(url, data) {
       for (var i = stubs.length - 1; i >= 0; i--) {
         var stub = stubs[i];
+        if (stub.url instanceof RegExp && url instanceof RegExp) {
+          return stub.url.toString() === url.toString();
+        }
         if (stub.matches(url, data)) {
           return stub;
         }
@@ -259,14 +262,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
 
   function RequestStub(url, stubData) {
-    var split = url.split('?');
-    this.url = split[0];
+    var split = [];
+    if (url instanceof RegExp) {
+      this.url = url;
+    } else {
+      split = url.split('?');
+      this.url = split[0];
+    }
 
     var normalizeQuery = function(query) {
       return query ? query.split('&').sort().join('&') : undefined;
     };
 
-    this.query = normalizeQuery(split[1]);
+    this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
     this.data = normalizeQuery(stubData);
 
     this.andReturn = function(options) {
@@ -277,10 +285,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     this.matches = function(fullUrl, data) {
-      var urlSplit = fullUrl.split('?'),
-          url = urlSplit[0],
-          query = urlSplit[1];
-      return this.url === url && this.query === normalizeQuery(query) && (!this.data || this.data === normalizeQuery(data));
+      var matches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        matches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        matches = this.url === url && this.query === normalizeQuery(query);
+      }
+      return matches && (!this.data || this.data === normalizeQuery(data));
     };
   }
 
@@ -292,4 +307,3 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     jasmine.Ajax = new MockAjax(window);
   }
 }());
-

--- a/spec/javascripts/mock-ajax-spec.js
+++ b/spec/javascripts/mock-ajax-spec.js
@@ -44,6 +44,22 @@ describe("mockAjax", function() {
     expect(mockAjax.stubs.findStub('/bobcat')).not.toBeDefined();
   });
 
+  it("allows stubs to use RegExp", function () {
+    var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
+        fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },
+        mockAjax = new MockAjax(fakeGlobal);
+
+    mockAjax.install();
+    mockAjax.uninstall();
+
+    var regExpStub = mockAjax.stubRequest(/^bobcat/i);
+    var stringStub = mockAjax.stubRequest('/bobcat');
+
+    expect(mockAjax.stubs.findStub(/^bobcat/i)).toBeDefined();
+    expect(mockAjax.stubs.findStub('/bobcat')).toBeDefined();
+    expect(regExpStub.matches('/BOBCAT'));
+  });
+
   it("allows the httpRequest to be retrieved", function() {
     var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
         fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },


### PR DESCRIPTION
I've noticed some folks asking for partial matches (#66), and I myself have needed to match jsonp requests meaning I'll never know the padding. I thought that allowing for a regex matched stub would be really useful.
