### PR TITLE
Add some files to the bower.json ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,10 +20,16 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
-    "node_modules",
-    "bower_components",
+    "Gemfile",
+    "Gemfile.lock",
+    "Gruntfile",
+    "Rakefile",
     "app/bower_components",
+    "bower_components",
+    "node_modules",
+    "spec",
     "test",
-    "tests"
+    "tests",
+    "travis-script.sh"
   ]
 }


### PR DESCRIPTION
When installing this package with Bower, a bunch of extra files come
along for the ride that aren't needed. This commit adds them to the
ignore list so they will not be install by consumers using Bower.

While I was at it, I sorted the list.
