### PR TITLE
Un-pin jasmine dependency from version 2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "description": "A library for faking Ajax responses in your Jasmine suite.",
   "main": "lib/mock-ajax.js",
   "dependencies": {
-    "jasmine" : "2.0.0"
+    "jasmine" : "~2.0"
   },
   "moduleType": [
     "globals"


### PR DESCRIPTION
Feel free to reject this if it's meant to be pinned to jasmine 2.0.0
