### PR TITLE
Added onloadend() callback for XHRs

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -135,6 +135,9 @@ getJasmineRequireObj().AjaxFakeRequest = function() {
       onload: function() {
       },
 
+      onloadend: function() {
+      },
+
       onreadystatechange: function(isTimeout) {
       },
 
@@ -202,6 +205,7 @@ getJasmineRequireObj().AjaxFakeRequest = function() {
 
         this.onload();
         this.onreadystatechange();
+        this.onloadend();
       },
 
       responseTimeout: function() {


### PR DESCRIPTION
I didn't look into this too carefully but in my application I wanted the onloadend callback for testing. With respect to Chrome, Safari, and Firefox, the onloadend callback is executed after the final onreadystatechange.
