### PR TITLE
Dojo compatibility

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -204,9 +204,17 @@ getJasmineRequireObj().AjaxFakeRequest = function() {
             self = this;
 
         this.events[event] = function() {
-          callback.apply(self);
+          callback.apply(self, [{}]);
           existingCallback();
         };
+      },
+      
+      removeEventListener: function(event, callback) {
+        var existingCallback = this.events[event];
+
+        if(existingCallback){
+          delete this.events[event];
+        }
       },
 
       status: null,

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -159,9 +159,17 @@ getJasmineRequireObj().AjaxFakeRequest = function() {
             self = this;
 
         this.events[event] = function() {
-          callback.apply(self);
+          callback.apply(self, [{}]);
           existingCallback();
         };
+      },
+      
+      removeEventListener: function(event, callback) {
+        var existingCallback = this.events[event];
+
+        if(existingCallback){
+          delete this.events[event];
+        }
       },
 
       status: null,


### PR DESCRIPTION
Hi,

While trying to test a project in Dojo, I ran into some trouble when faking xhrs.

1) Dojo's xhr wrapper doesn't check for a null event parameter in its callbacks, so I added an empty object to the callback.apply [line 207]

2) Dojo calls removeEventListener with a modified context, which throws a TypeError: Illegal invocation. Faking this function solves the issue.


Cheers,
Jeremy