### PR TITLE
Add `responseHeaders` to `andReturn` s options

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -466,6 +466,7 @@ getJasmineRequireObj().AjaxRequestStub = function() {
       this.contentType = options.contentType;
       this.response = options.response;
       this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
     };
 
     this.matches = function(fullUrl, data, method) {

--- a/spec/integration/webmock-style-spec.js
+++ b/spec/integration/webmock-style-spec.js
@@ -51,6 +51,15 @@ describe("Webmock style mocking", function() {
     expect(response.status).toEqual(200);
   });
 
+  it("should set the responseHeaders", function() {
+    mockAjax.stubRequest("http://example.com/someApi").andReturn({
+      responseText: "hi!",
+      responseHeaders: [{name: "X-Custom", value: "header value"}]
+    });
+    sendRequest(fakeGlobal);
+    expect(response.getResponseHeader('X-Custom')).toEqual('header value');
+  });
+
   describe("with another stub for the same url", function() {
     beforeEach(function() {
       mockAjax.stubRequest("http://example.com/someApi").andReturn({responseText: "no", status: 403});

--- a/src/requestStub.js
+++ b/src/requestStub.js
@@ -22,6 +22,7 @@ getJasmineRequireObj().AjaxRequestStub = function() {
       this.contentType = options.contentType;
       this.response = options.response;
       this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
     };
 
     this.matches = function(fullUrl, data, method) {


### PR DESCRIPTION
Is there any reason, why it's not there?
```js
jasmine.Ajax.stubRequest('/another/url').andReturn({
    "responseText": 'immediate response',
    "responseHeaders": [{"name": "My-Header", "value": "tomalec"}]
});
```
seems quite useful.