### PR TITLE
fix for node.js

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -725,7 +725,7 @@ getJasmineRequireObj().AjaxStubTracker = function() {
       MockAjax = jRequire.ajax(jRequire);
   if (typeof window === "undefined" && typeof exports === "object") {
     exports.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(exports);
+    jasmine.Ajax = new MockAjax(global);
   } else {
     window.MockAjax = MockAjax;
     jasmine.Ajax = new MockAjax(window);

--- a/src/boot.js
+++ b/src/boot.js
@@ -3,7 +3,7 @@
       MockAjax = jRequire.ajax(jRequire);
   if (typeof window === "undefined" && typeof exports === "object") {
     exports.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(exports);
+    jasmine.Ajax = new MockAjax(global);
   } else {
     window.MockAjax = MockAjax;
     jasmine.Ajax = new MockAjax(window);


### PR DESCRIPTION
it fixes this issue https://github.com/jasmine/jasmine-ajax/issues/95

Install:
```
npm install xhr2
```

Use next:
```
node ./jasmine.js
```

jasmine.js:
```javascript
'use strict';

var Jasmine = require('jasmine');
var jasmine = new Jasmine();

global.getJasmineRequireObj = (function (jasmineGlobal) {
    var jasmineRequire;

    jasmineGlobal = jasmineGlobal || global;
    if (typeof module !== 'undefined' && module.exports) {
        jasmineGlobal = global;
        jasmineRequire = exports;
    } else {
        if (typeof window !== 'undefined' && typeof window.toString === 'function' && window.toString() === '[object GjsGlobal]') {
            jasmineGlobal = window;
        }
        jasmineRequire = jasmineGlobal.jasmineRequire = jasmineGlobal.jasmineRequire || {};
    }

    function getJasmineRequire() {
        return jasmineRequire;
    }

    return getJasmineRequire;
})(this);

global.XMLHttpRequest = require('xhr2');
require('jasmine-ajax');

jasmine.loadConfigFile('spec/support/jasmine.json');

jasmine.configureDefaultReporter({
    showColors: true
});
jasmine.execute();
```