### PR TITLE
Throw exception on multiple calls to jasmine.Ajax.uninstall.

### DIFF
--- a/spec/integration/mock-ajax-spec.js
+++ b/spec/integration/mock-ajax-spec.js
@@ -26,6 +26,20 @@ describe("mockAjax", function() {
     expect(sequentialInstalls).not.toThrow();
   });
 
+  it("does throw an error if uninstalled without a current install", function() {
+    var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
+      fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },
+      mockAjax = new window.MockAjax(fakeGlobal);
+
+    function sequentialUninstalls() {
+      mockAjax.install();
+      mockAjax.uninstall();
+      mockAjax.uninstall();
+    }
+
+    expect(sequentialUninstalls).toThrow();
+  });
+
   it("does not replace XMLHttpRequest until it is installed", function() {
     var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
         fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },

--- a/src/mockAjax.js
+++ b/src/mockAjax.js
@@ -15,6 +15,9 @@ getJasmineRequireObj().MockAjax = function($ajax) {
     };
 
     this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw "MockAjax not installed. Race conditions between running tests may be uninstalling MockAjax early.";
+      }
       global.XMLHttpRequest = realAjaxFunction;
 
       this.stubs.reset();


### PR DESCRIPTION
Add an error to alert Jasmine users to possible race conditions in mocking-unmocking ajax calls.