### PR TITLE
Remove requests from the RequestTracker

### DIFF
--- a/src/requestTracker.js
+++ b/src/requestTracker.js
@@ -13,6 +13,10 @@ getJasmineRequireObj().AjaxRequestTracker = function() {
     this.count = function() {
       return requests.length;
     };
+    
+    this.remove = function(index) {
+      requests.splice(index, 1);
+    };    
 
     this.reset = function() {
       requests = [];


### PR DESCRIPTION
It's possible to track new requests and filter them but it's not possible to remove a specific request from the `RequestTracker`. Because the access to the `requests` member is hidden I propose my file change to make it possible to remove a request object.