### PR TITLE
Minimum modification to adapt node.js (still uncomfortable)

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -728,7 +728,7 @@ getJasmineRequireObj().AjaxStubTracker = function() {
       MockAjax = jRequire.ajax(jRequire);
   if (typeof window === "undefined" && typeof exports === "object") {
     exports.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(exports);
+    jasmine.Ajax = new MockAjax(this);
   } else {
     window.MockAjax = MockAjax;
     jasmine.Ajax = new MockAjax(window);

--- a/src/boot.js
+++ b/src/boot.js
@@ -3,7 +3,19 @@
       MockAjax = jRequire.ajax(jRequire);
   if (typeof window === "undefined" && typeof exports === "object") {
     exports.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(exports);
+
+    /**
+     * jasmine is an instance of require('jasmine') in node.js
+     * we may not use jasmine to execute our specs
+     * then set it manually like this:
+     *
+     * var jas = new new Jasmine();
+     * var jasmineAjax = require('jasmine-ajax');
+     * jas.Ajax = new jasmineAjax.MockAjax(global);
+     */
+    if (typeof jasmine !== 'undefined') {
+      jasmine.Ajax = new MockAjax(this);
+    }
   } else {
     window.MockAjax = MockAjax;
     jasmine.Ajax = new MockAjax(window);


### PR DESCRIPTION
The error detail is obvious in node.js.
Just because you did not pass the right global object to MockAjax, so you have no XMLHttpRequest.

```js
(function() {
  var jRequire = getJasmineRequireObj(),
      MockAjax = jRequire.ajax(jRequire);
  if (typeof window === "undefined" && typeof exports === "object") {
    exports.MockAjax = MockAjax;
    // exports is not the global object but this library
    jasmine.Ajax = new MockAjax(exports);
  } else {
    window.MockAjax = MockAjax;
    jasmine.Ajax = new MockAjax(window);
  }
}());
```

So I made some change like this:

```js
(function() {
  var jRequire = getJasmineRequireObj(),
      MockAjax = jRequire.ajax(jRequire);
  if (typeof window === "undefined" && typeof exports === "object") {
    exports.MockAjax = MockAjax;

    /**
     * jasmine is an instance of require('jasmine') in node.js
     * we may not use jasmine to execute our specs
     * then set it manually like this:
     *
     * var jas = new new Jasmine();
     * var jasmineAjax = require('jasmine-ajax');
     * jas.Ajax = new jasmineAjax.MockAjax(global);
     */
    if (typeof jasmine !== 'undefined') {
      jasmine.Ajax = new MockAjax(this);
    }
  } else {
    window.MockAjax = MockAjax;
    jasmine.Ajax = new MockAjax(window);
  }
}());
```

But there is still a global variable problem about `getJasmineRequireObj`.

Since we need the minimum modification, I prefer to add `getJasmineRequireObj` manually.

And finally we got this:

```js
var Jasmine = require('jasmine')
// direct dependacy for getJasmineRequireObj
var JasmineCore = require('jasmine-core')

// jasmine-ajax need this global varaible
global.getJasmineRequireObj = function() {
  return JasmineCore
}
global.XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest

var jasmine = new Jasmine({
  jasmineCore: JasmineCore
})
require('jasmine-ajax')

// now we can run our specs now
```

I am using this code to run my unit tests in both [browser](https://github.com/simongfxu/dcagent/blob/master/test/runner.js) and [node.js](https://github.com/simongfxu/dcagent/blob/master/test/node-runner.js), and it lookes like it works.