### PR TITLE
get jasmineRequire in CommonJS environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.tmp/
 .rvmrc
 *.swp
 bower_components

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,7 @@ module.exports = function( grunt ) {
         sub: true,
         undef: true,
         globals: {
+          global: true,
           jasmine: false,
           module: false,
           exports: true,
@@ -53,21 +54,34 @@ module.exports = function( grunt ) {
         ].join('&&')
       }
     },
-    concat: {
-      options: {
-        process: true
-      },
-      mockAjax: {
-        src: [
-          'src/requireAjax.js',
-          'src/**/*.js',
-          '!src/boot.js',
-          'src/boot.js'
-        ],
-        dest: 'lib/mock-ajax.js'
-      }
+    template: {
+        options: {
+            data: function() {
+                return {
+                    packageVersion: packageVersion(),
+                    files: grunt.file.expand([
+                        'src/requireAjax.js',
+                        'src/**/*.js',
+                        '!src/boot.js'
+                    ])
+                };
+            }
+        },
+        lib: {
+            src: 'src/boot.js',
+            dest: '.tmp/mock-ajax.js'
+        }
     },
-    packageVersion: packageVersion()
+    includes: {
+        options: {
+            includeRegexp: /\/\/\s*include "(\S+)";/,
+            includePath: '.'
+        },
+        lib: {
+            src: '.tmp/mock-ajax.js',
+            dest: 'lib/mock-ajax.js'
+        }
+    }
   });
 
   grunt.registerTask('versionCheck', function() {
@@ -81,10 +95,12 @@ module.exports = function( grunt ) {
   });
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-template');
+  grunt.loadNpmTasks('grunt-includes');
   grunt.loadNpmTasks('grunt-shell');
 
   grunt.registerTask('default', ['jshint']);
+  grunt.registerTask('build', ['template:lib', 'includes:lib']);
   grunt.registerTask('ctags', 'Generate ctags', ['shell:ctags']);
   grunt.registerTask('release', 'Release ' + packageVersion() + ' to npm', ['versionCheck', 'shell:release']);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "3.2.0",
   "main": "lib/mock-ajax.js",
   "license": "MIT",
-
   "url": "https://github.com/jasmine/jasmine-ajax",
   "contributors": [
     "Gregg Van Hove <gregg@slackersoft.net>",
@@ -17,10 +16,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "grunt": "0.4.0",
+    "grunt": "~0.4.0",
     "grunt-cli": "~0.1.13",
-    "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-jshint": "~0.1.1",
-    "grunt-shell": "~0.2.1"
+    "grunt-includes": "^0.5.1",
+    "grunt-shell": "~0.2.1",
+    "grunt-template": "^0.2.3"
   }
 }

--- a/src/boot.js
+++ b/src/boot.js
@@ -1,11 +1,55 @@
-(function() {
-  var jRequire = getJasmineRequireObj(),
-      MockAjax = jRequire.ajax(jRequire);
-  if (typeof window === "undefined" && typeof exports === "object") {
-    exports.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(exports);
-  } else {
-    window.MockAjax = MockAjax;
-    jasmine.Ajax = new MockAjax(window);
-  }
-}());
+/*
+
+Jasmine-Ajax - v<%= packageVersion %>: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // CommonJS
+        var jasmineRequire = require('jasmine-core');
+        module.exports = factory(root, function() {
+            return jasmineRequire;
+        });
+    } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+// <% files.forEach(function(filename) { %>
+//  include "<%= filename %>";<% }); %>
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));

--- a/src/requireAjax.js
+++ b/src/requireAjax.js
@@ -1,35 +1,3 @@
-/*
-
-Jasmine-Ajax - v<%= packageVersion %>: a set of helpers for testing AJAX requests under the Jasmine
-BDD framework for JavaScript.
-
-http://github.com/jasmine/jasmine-ajax
-
-Jasmine Home page: http://jasmine.github.io/
-
-Copyright (c) 2008-2015 Pivotal Labs
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
-
 getJasmineRequireObj().ajax = function(jRequire) {
   var $ajax = {};
 


### PR DESCRIPTION
fixes #95 

In CommonJS environment the function `getJasmineRequireObj` is undefined. But `jasmineRequire` object available via `require('jasmine-core')`.

It is worked for me, but looks little hacky. I am going to create UMD-wrapper around entire library to make it work in any environment: 

```js
(function (root, factory) {
    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
        // CommonJS
        module.exports = factory(require('jasmine-core'));
    } else {
        // Browser globals
        window.MockAjax = factory(getJasmineRequireObj());
    }
}(this, function (jasmineRequire) {

   //put jasmine-ajax code here

   jasmine.Ajax = new MockAjax(exports);
   return MockAjax;
}));
```

What do you think about it?