### PR TITLE
Various improvements

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //Module wrapper to support both browser and CommonJS environment
 (function (root, factory) {
-    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+    if (typeof jasmine === 'undefined' && typeof exports === 'object' && typeof exports.nodeName !== 'string') {
         // CommonJS
         var jasmineRequire = require('jasmine-core');
         module.exports = factory(root, function() {
@@ -345,6 +345,11 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('loadstart');
 
         var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
         if (stub) {
           if (stub.isReturn()) {
             this.respondWith(stub);
@@ -352,6 +357,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
             this.responseError();
           } else if (stub.isTimeout()) {
             this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
           }
         }
       },
@@ -469,6 +476,12 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('progress');
         this.eventBus.trigger('error');
         this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
       }
     });
 
@@ -496,7 +509,7 @@ getJasmineRequireObj().MockAjax = function($ajax) {
 
     this.uninstall = function() {
       if (global.XMLHttpRequest !== mockAjaxFunction) {
-        throw "MockAjax not installed.";
+        return;
       }
       global.XMLHttpRequest = realAjaxFunction;
 
@@ -591,7 +604,8 @@ getJasmineRequireObj().AjaxParamParser = function() {
 getJasmineRequireObj().AjaxRequestStub = function() {
   var RETURN = 0,
       ERROR = 1,
-      TIMEOUT = 2;
+      TIMEOUT = 2,
+      CALL = 3;
 
   function RequestStub(url, stubData, method) {
     var normalizeQuery = function(query) {
@@ -639,6 +653,15 @@ getJasmineRequireObj().AjaxRequestStub = function() {
 
     this.isTimeout = function() {
       return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
     };
 
     this.matches = function(fullUrl, data, method) {

--- a/spec/integration/mock-ajax-spec.js
+++ b/spec/integration/mock-ajax-spec.js
@@ -26,14 +26,14 @@ describe("mockAjax", function() {
     expect(sequentialInstalls).not.toThrow();
   });
 
-  it("does throw an error if uninstalled without a current install", function() {
+  it("does not throw an error if uninstalled without a current install", function() {
     var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
       fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },
       mockAjax = new window.MockAjax(fakeGlobal);
 
     expect(function() {
       mockAjax.uninstall();
-    }).toThrow();
+    }).not.toThrow();
   });
 
   it("does not replace XMLHttpRequest until it is installed", function() {

--- a/src/boot.js
+++ b/src/boot.js
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //Module wrapper to support both browser and CommonJS environment
 (function (root, factory) {
-    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+    if (typeof jasmine === 'undefined' && typeof exports === 'object' && typeof exports.nodeName !== 'string') {
         // CommonJS
         var jasmineRequire = require('jasmine-core');
         module.exports = factory(root, function() {

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -168,6 +168,11 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('loadstart');
 
         var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
         if (stub) {
           if (stub.isReturn()) {
             this.respondWith(stub);
@@ -175,6 +180,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
             this.responseError();
           } else if (stub.isTimeout()) {
             this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
           }
         }
       },
@@ -292,6 +299,12 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('progress');
         this.eventBus.trigger('error');
         this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
       }
     });
 

--- a/src/mockAjax.js
+++ b/src/mockAjax.js
@@ -16,7 +16,7 @@ getJasmineRequireObj().MockAjax = function($ajax) {
 
     this.uninstall = function() {
       if (global.XMLHttpRequest !== mockAjaxFunction) {
-        throw "MockAjax not installed.";
+        return;
       }
       global.XMLHttpRequest = realAjaxFunction;
 

--- a/src/requestStub.js
+++ b/src/requestStub.js
@@ -1,7 +1,8 @@
 getJasmineRequireObj().AjaxRequestStub = function() {
   var RETURN = 0,
       ERROR = 1,
-      TIMEOUT = 2;
+      TIMEOUT = 2,
+      CALL = 3;
 
   function RequestStub(url, stubData, method) {
     var normalizeQuery = function(query) {
@@ -49,6 +50,15 @@ getJasmineRequireObj().AjaxRequestStub = function() {
 
     this.isTimeout = function() {
       return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
     };
 
     this.matches = function(fullUrl, data, method) {


### PR DESCRIPTION
Sorry this pull request is a bit of grab bag; it represents several changes that were extremely useful in my project and hopefully won't be too controversial.  If any parts do turn out to be controversial, I can break the other parts into separate pull requests.

Here are the changes and the rationale:

* Check for a global `jasmine` and use it if found, rather than requiring-in `jasmine-core` in any CommonJS environment.  This makes jasmine-ajax work in a Browserify environment where Jasmine itself is included with a script tag (e.g. using the regular SpecRunner.html).

* Silently ignore a call to `uninstall` (instead of throwing) when the `mockAjaxFunction` is not installed.  This way we can uninstall defensively in a global `afterEach`.

* Add `RequestStub.andCallFunction`.  The provided function is called with the stub and the fake XHR object when the stub matches a request, and it can inspect the request and then call the usual `andReturn`, `andError`, `andTimeout` functions based on the result.  This lets us do handy things like:

```javascript
        // Make requests for unhandled URLs fail the test and report the problematic URL.
        jasmine.Ajax.stubRequest(/.*/).andCallFunction(function(stub, xhr) {
            done.fail('Unhandled request to URL: ' + xhr.url);
        });
```

Or:

```javascript
        // Verify that a URL meets some rules that can't be easily expressed as a regexp
        jasmine.Ajax.stubRequest(/www.example.com\/whatever\//).andCallFunction(function(stub, xhr) {
            if (anyOldFunctionToVerifyTheUrl(xhr.url)) {
                stub.andReturn({
                    textResponse: 'my response'
                });
            } else {
                done.fail('URL is no good!');
            }
        });
```
