### PR TITLE
Check for a global jasmine and use it if found.

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //Module wrapper to support both browser and CommonJS environment
 (function (root, factory) {
-    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+    if (typeof jasmine === 'undefined' && typeof exports === 'object' && typeof exports.nodeName !== 'string') {
         // CommonJS
         var jasmineRequire = require('jasmine-core');
         module.exports = factory(root, function() {

--- a/src/boot.js
+++ b/src/boot.js
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //Module wrapper to support both browser and CommonJS environment
 (function (root, factory) {
-    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+    if (typeof jasmine === 'undefined' && typeof exports === 'object' && typeof exports.nodeName !== 'string') {
         // CommonJS
         var jasmineRequire = require('jasmine-core');
         module.exports = factory(root, function() {


### PR DESCRIPTION
This makes jasmine-ajax work with Browserify.  Browserify is a CommonJS environment, but it runs in a browser and doesn't play nicely with `jasmine-core` (or at least I had trouble using it in my project).  The way we use Jasmine - and I suspect this isn't uncommon - is we include Jasmine and our Browserify-built bundle using regular script tags.  So `jasmine` is global and requiring-in `jasmine-core` is incorrect, even though we are in a CommonJS environment.

This change only checks whether a global `jasmine` is defined.  A slightly more defensive approach - but perhaps overkill? - would be to also check for particular properties on that `jasmine` object.  i.e.: make sure it's the right jasmine.
