### PR TITLE
Don't throw on uninstall if not already installed.

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -496,7 +496,7 @@ getJasmineRequireObj().MockAjax = function($ajax) {
 
     this.uninstall = function() {
       if (global.XMLHttpRequest !== mockAjaxFunction) {
-        throw "MockAjax not installed.";
+        return;
       }
       global.XMLHttpRequest = realAjaxFunction;
 

--- a/spec/integration/mock-ajax-spec.js
+++ b/spec/integration/mock-ajax-spec.js
@@ -26,14 +26,14 @@ describe("mockAjax", function() {
     expect(sequentialInstalls).not.toThrow();
   });
 
-  it("does throw an error if uninstalled without a current install", function() {
+  it("does not throw an error if uninstalled without a current install", function() {
     var fakeXmlHttpRequest = jasmine.createSpy('fakeXmlHttpRequest'),
       fakeGlobal = { XMLHttpRequest: fakeXmlHttpRequest },
       mockAjax = new window.MockAjax(fakeGlobal);
 
     expect(function() {
       mockAjax.uninstall();
-    }).toThrow();
+    }).not.toThrow();
   });
 
   it("does not replace XMLHttpRequest until it is installed", function() {

--- a/src/mockAjax.js
+++ b/src/mockAjax.js
@@ -16,7 +16,7 @@ getJasmineRequireObj().MockAjax = function($ajax) {
 
     this.uninstall = function() {
       if (global.XMLHttpRequest !== mockAjaxFunction) {
-        throw "MockAjax not installed.";
+        return;
       }
       global.XMLHttpRequest = realAjaxFunction;
 


### PR DESCRIPTION
I've found it handy in my specs to let individual specs install jasmine-ajax as needed (sometimes after downloading local resources that are awkward to include in the source code), and use a global `afterEach` to uninstall it.  This way each spec doesn't need to remember to uninstall it itself.

Unfortunately this is not currently (before this PR) possible because: 1) `uninstall` throws if jasmine-ajax is not already installed, and 2) there's is no way (that I see) to determine ahead of time if it has been installed.

So this PR simply changes `uninstall` to not throw, since that choice seems somewhat arbitrary anyway.  Obviously I can just catch the exception in my `afterEach` if you're opposed to this change, but that's a bit ugly.