### PR TITLE
Add `RequestStub.andCallFunction.

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -345,6 +345,11 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('loadstart');
 
         var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
         if (stub) {
           if (stub.isReturn()) {
             this.respondWith(stub);
@@ -352,6 +357,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
             this.responseError();
           } else if (stub.isTimeout()) {
             this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
           }
         }
       },
@@ -469,6 +476,12 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('progress');
         this.eventBus.trigger('error');
         this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
       }
     });
 
@@ -591,7 +604,8 @@ getJasmineRequireObj().AjaxParamParser = function() {
 getJasmineRequireObj().AjaxRequestStub = function() {
   var RETURN = 0,
       ERROR = 1,
-      TIMEOUT = 2;
+      TIMEOUT = 2,
+      CALL = 3;
 
   function RequestStub(url, stubData, method) {
     var normalizeQuery = function(query) {
@@ -639,6 +653,15 @@ getJasmineRequireObj().AjaxRequestStub = function() {
 
     this.isTimeout = function() {
       return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
     };
 
     this.matches = function(fullUrl, data, method) {

--- a/spec/fakeRequestSpec.js
+++ b/spec/fakeRequestSpec.js
@@ -714,4 +714,94 @@ describe('FakeRequest', function() {
 
     expect(request.response).toEqual('foo');
   });
+
+  describe('function response', function() {
+    it('can return a response', function() {
+      var request = new this.FakeRequest();
+      request.open();
+      request.send();
+
+      function f(stub, request) {
+        expect(stub.action).toBeUndefined();
+        stub.isReturn = function() { return true; };
+        stub.isError = function() { return false; };
+        stub.isTimeout = function() { return false; };
+        stub.isCallFunction = function() { return false; };
+        stub.responseText = 'foo';
+      }
+
+      request.responseCallFunction({ functionToCall: f });
+
+      expect(request.response).toEqual('foo');
+    });
+
+    it('can return an error', function() {
+      var request = new this.FakeRequest();
+      request.open();
+      request.send();
+
+      this.fakeEventBus.trigger.calls.reset();
+
+      function f(stub, request) {
+        expect(stub.action).toBeUndefined();
+        stub.isReturn = function() { return false; };
+        stub.isError = function() { return true; };
+        stub.isTimeout = function() { return false; };
+        stub.isCallFunction = function() { return false; };
+      }
+
+      request.responseCallFunction({ functionToCall: f });
+
+      expect(this.fakeEventBus.trigger).toHaveBeenCalledWith('error');
+    });
+
+    it('can return a timeout', function() {
+      var request = new this.FakeRequest();
+      request.open();
+      request.send();
+
+      this.fakeEventBus.trigger.calls.reset();
+
+      function f(stub, request) {
+        expect(stub.action).toBeUndefined();
+        stub.isReturn = function() { return false; };
+        stub.isError = function() { return false; };
+        stub.isTimeout = function() { return true; };
+        stub.isCallFunction = function() { return false; };
+      }
+
+      jasmine.clock().install();
+      request.responseCallFunction({ functionToCall: f });
+      jasmine.clock().uninstall();
+
+      expect(this.fakeEventBus.trigger).toHaveBeenCalledWith('timeout');
+    });
+
+    it('can chain to another function', function() {
+      var request = new this.FakeRequest();
+      request.open();
+      request.send();
+
+      this.fakeEventBus.trigger.calls.reset();
+
+      var calls = 0;
+      function f(stub, request) {
+        expect(stub.action).toBeUndefined();
+        stub.isReturn = function() { return false; };
+        stub.isError = function() { return false; };
+        stub.isTimeout = function() { return false; };
+
+        ++calls;
+        if (calls > 1) {
+          stub.isCallFunction = function() { return false; };
+        } else {
+          stub.isCallFunction = function() { return true; };
+        }
+      }
+
+      request.responseCallFunction({ functionToCall: f });
+
+      expect(calls).toBe(2);
+    });
+  });
 });

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -168,6 +168,11 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('loadstart');
 
         var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
         if (stub) {
           if (stub.isReturn()) {
             this.respondWith(stub);
@@ -175,6 +180,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
             this.responseError();
           } else if (stub.isTimeout()) {
             this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
           }
         }
       },
@@ -292,6 +299,12 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
         this.eventBus.trigger('progress');
         this.eventBus.trigger('error');
         this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
       }
     });
 

--- a/src/requestStub.js
+++ b/src/requestStub.js
@@ -1,7 +1,8 @@
 getJasmineRequireObj().AjaxRequestStub = function() {
   var RETURN = 0,
       ERROR = 1,
-      TIMEOUT = 2;
+      TIMEOUT = 2,
+      CALL = 3;
 
   function RequestStub(url, stubData, method) {
     var normalizeQuery = function(query) {
@@ -49,6 +50,15 @@ getJasmineRequireObj().AjaxRequestStub = function() {
 
     this.isTimeout = function() {
       return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
     };
 
     this.matches = function(fullUrl, data, method) {


### PR DESCRIPTION
The provided function is called with the stub and the fake XHR object when the stub matches a request, and it can inspect the request and then call the usual `andReturn`, `andError`, `andTimeout` functions based on the result.

This lets us do handy things like:

```javascript
        // Make requests for unhandled URLs fail the test and report the problematic URL.
        jasmine.Ajax.stubRequest(/.*/).andCallFunction(function(stub, xhr) {
            done.fail('Unhandled request to URL: ' + xhr.url);
        });
```

(the above was my main motivation for adding this)

Or:

```javascript
        // Verify that a URL meets some rules that can't be easily expressed as a regexp
        jasmine.Ajax.stubRequest(/www.example.com\/whatever\//).andCallFunction(function(stub, xhr) {
            if (anyOldFunctionToVerifyTheUrl(xhr.url)) {
                stub.andReturn({
                    textResponse: 'my response'
                });
            } else {
                done.fail('URL is no good!');
            }
        });
```
