### PR TITLE
Bugfix for getResponseHeader and getAllResponseHeaders

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -377,6 +377,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
 
       getResponseHeader: function(name) {
         var resultHeader = null;
+        if (!this.responseHeaders) { return resultHeader; }
+
         name = name.toLowerCase();
         for(var i = 0; i < this.responseHeaders.length; i++) {
           var header = this.responseHeaders[i];
@@ -392,6 +394,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
       },
 
       getAllResponseHeaders: function() {
+        if (!this.responseHeaders) { return null; }
+
         var responseHeaders = [];
         for (var i = 0; i < this.responseHeaders.length; i++) {
           responseHeaders.push(this.responseHeaders[i].name + ': ' +

--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -376,8 +376,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
       },
 
       getResponseHeader: function(name) {
+        var resultHeader = null;
         name = name.toLowerCase();
-        var resultHeader;
         for(var i = 0; i < this.responseHeaders.length; i++) {
           var header = this.responseHeaders[i];
           if (name === header.name.toLowerCase()) {

--- a/spec/fakeRequestSpec.js
+++ b/spec/fakeRequestSpec.js
@@ -112,6 +112,16 @@ describe('FakeRequest', function() {
     expect(request.requestHeaders).toEqual({});
   });
 
+  it('getResponseHeader returns null, if no response has been received', function() {
+    var request = new this.FakeRequest();
+    expect(request.getResponseHeader('XY')).toBe(null);
+  });
+
+  it('getAllResponseHeaders returns null, if no response has been received', function() {
+    var request = new this.FakeRequest();
+    expect(request.getAllResponseHeaders()).toBe(null);
+  });
+
   describe('managing readyState', function() {
     beforeEach(function() {
       this.request = new this.FakeRequest();

--- a/spec/mock-ajax-toplevel-spec.js
+++ b/spec/mock-ajax-toplevel-spec.js
@@ -321,6 +321,10 @@ describe("Jasmine Mock Ajax (for toplevel)", function() {
         expect(response.getResponseHeader('X-Header')).toBe('header value 1, header value 2');
       });
 
+      it("returns null, if header does not exist", function() {
+        expect(response.getResponseHeader('X-Does-Not-Exist')).toBe(null);
+      });
+
       it("getAllResponseHeaders should return all values", function () {
         expect(response.getAllResponseHeaders()).toBe([
           "X-Header: header value 1",

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -199,8 +199,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
       },
 
       getResponseHeader: function(name) {
+        var resultHeader = null;
         name = name.toLowerCase();
-        var resultHeader;
         for(var i = 0; i < this.responseHeaders.length; i++) {
           var header = this.responseHeaders[i];
           if (name === header.name.toLowerCase()) {

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -200,6 +200,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
 
       getResponseHeader: function(name) {
         var resultHeader = null;
+        if (!this.responseHeaders) { return resultHeader; }
+
         name = name.toLowerCase();
         for(var i = 0; i < this.responseHeaders.length; i++) {
           var header = this.responseHeaders[i];
@@ -215,6 +217,8 @@ getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
       },
 
       getAllResponseHeaders: function() {
+        if (!this.responseHeaders) { return null; }
+
         var responseHeaders = [];
         for (var i = 0; i < this.responseHeaders.length; i++) {
           responseHeaders.push(this.responseHeaders[i].name + ': ' +


### PR DESCRIPTION
This PR fixes #153 and makes `getResponseHeader` and `getAllResponseHeaders` be more compliant with browser standards.

> A ByteString representing the header's text value, or null if either the response has not yet been received or the header doesn't exist in the response.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getResponseHeader

> [...] or null if no response has been received.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
