### PR TITLE
Add status and statusText to responseError. Defaults to 500.

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -366,7 +366,7 @@ extend(FakeXMLHttpRequest, {
           if (stub.isReturn()) {
             this.respondWith(stub);
           } else if (stub.isError()) {
-            this.responseError();
+            this.responseError(stub);
           } else if (stub.isTimeout()) {
             this.responseTimeout();
           } else if (stub.isCallFunction()) {
@@ -483,10 +483,15 @@ extend(FakeXMLHttpRequest, {
         this.eventBus.trigger('loadend');
       },
 
-      responseError: function() {
+      responseError: function(response) {
+        if (!response) {
+          response = {};
+        }
         if (this.readyState === FakeXMLHttpRequest.DONE) {
           throw new Error("FakeXMLHttpRequest already completed");
         }
+        this.status = response.status;
+        this.statusText = response.statusText || "";
         this.readyState = FakeXMLHttpRequest.DONE;
         this.eventBus.trigger('readystatechange');
         this.eventBus.trigger('progress');
@@ -655,8 +660,12 @@ getJasmineRequireObj().AjaxRequestStub = function() {
       return this.action === RETURN;
     };
 
-    this.andError = function() {
+    this.andError = function(options) {
+      if (!options) {
+        options = {};
+      }
       this.action = ERROR;
+      this.status = options.status || 500;
     };
 
     this.isError = function() {

--- a/spec/fakeRequestSpec.js
+++ b/spec/fakeRequestSpec.js
@@ -500,6 +500,29 @@ describe('FakeRequest', function() {
     expect(request.statusText).toBe('OK');
   });
 
+  it('has a status from the response when there is an error', function() {
+    var request = new this.FakeRequest();
+    request.open();
+    request.send();
+
+    request.responseError({ status: 500 });
+
+    expect(request.status).toBe(500);
+    expect(request.statusText).toBe('');
+  });
+
+  it('has a statusText from the response when there is an error', function() {
+    var request = new this.FakeRequest();
+    request.open();
+    request.send();
+
+    request.responseError({ status: 500, statusText: 'Internal Server Error' });
+
+    expect(request.status).toBe(500);
+    expect(request.statusText).toBe('Internal Server Error');
+  });
+
+
   it('saves off any data sent to the server', function() {
     var request = new this.FakeRequest();
     request.open();

--- a/spec/requestStubSpec.js
+++ b/spec/requestStubSpec.js
@@ -69,4 +69,36 @@ describe('RequestStub', function() {
     expect(stub).toMatchRequest('/foo', 'baz=quux');
     expect(stub).not.toMatchRequest('/foo', 'foo=bar');
   });
+
+  describe('when returning successfully', function() {
+    it('isReturn', function() {
+      var stub = new this.RequestStub('/foo');
+      stub.andReturn({});
+
+      expect(stub.isReturn()).toBe(true);
+    });
+
+    it('defaults to status 200', function() {
+      var stub = new this.RequestStub('/foo');
+      stub.andReturn({});
+
+      expect(stub.status).toBe(200);
+    });
+  });
+
+  describe('when erroring', function() {
+    it('isReturn', function() {
+      var stub = new this.RequestStub('/foo');
+      stub.andError({});
+
+      expect(stub.isError()).toBe(true);
+    });
+
+    it('defaults to status 500', function() {
+      var stub = new this.RequestStub('/foo');
+      stub.andError({});
+
+      expect(stub.status).toBe(500);
+    });
+  });
 });

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -306,7 +306,10 @@ extend(FakeXMLHttpRequest, {
         this.eventBus.trigger('loadend');
       },
 
-      responseError: function(response = {}) {
+      responseError: function(response) {
+        if (!response) {
+          response = {};
+        }
         if (this.readyState === FakeXMLHttpRequest.DONE) {
           throw new Error("FakeXMLHttpRequest already completed");
         }

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -189,7 +189,7 @@ extend(FakeXMLHttpRequest, {
           if (stub.isReturn()) {
             this.respondWith(stub);
           } else if (stub.isError()) {
-            this.responseError();
+            this.responseError(stub);
           } else if (stub.isTimeout()) {
             this.responseTimeout();
           } else if (stub.isCallFunction()) {
@@ -306,10 +306,12 @@ extend(FakeXMLHttpRequest, {
         this.eventBus.trigger('loadend');
       },
 
-      responseError: function() {
+      responseError: function(response = {}) {
         if (this.readyState === FakeXMLHttpRequest.DONE) {
           throw new Error("FakeXMLHttpRequest already completed");
         }
+        this.status = response.status;
+        this.statusText = response.statusText || "";
         this.readyState = FakeXMLHttpRequest.DONE;
         this.eventBus.trigger('readystatechange');
         this.eventBus.trigger('progress');

--- a/src/requestStub.js
+++ b/src/requestStub.js
@@ -36,7 +36,10 @@ getJasmineRequireObj().AjaxRequestStub = function() {
       return this.action === RETURN;
     };
 
-    this.andError = function(options = {}) {
+    this.andError = function(options) {
+      if (!options) {
+        options = {};
+      }
       this.action = ERROR;
       this.status = options.status || 500;
     };

--- a/src/requestStub.js
+++ b/src/requestStub.js
@@ -36,8 +36,9 @@ getJasmineRequireObj().AjaxRequestStub = function() {
       return this.action === RETURN;
     };
 
-    this.andError = function() {
+    this.andError = function(options = {}) {
       this.action = ERROR;
+      this.status = options.status || 500;
     };
 
     this.isError = function() {


### PR DESCRIPTION
I set the new function parameters to default values of `{}` so that anyone using the existing parameterless version won't break when they upgrade. Let me know if you'd like to handle that differently!