### PR TITLE
respondWith allows responseJSON property shortcut for stringifing an object

### DIFF
--- a/lib/mock-ajax.js
+++ b/lib/mock-ajax.js
@@ -309,7 +309,7 @@ extend(FakeXMLHttpRequest, {
         if (this.readyState === 0) {
           throw new Error('DOMException: Failed to execute "setRequestHeader" on "XMLHttpRequest": The object\'s state must be OPENED.');
         }
-        
+
         if(this.requestHeaders.hasOwnProperty(header)) {
           this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
         } else {
@@ -457,6 +457,9 @@ extend(FakeXMLHttpRequest, {
         this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
         if (this.responseXML) {
           this.responseType = 'document';
+        }
+        if (response.responseJSON) {
+          this.responseText = JSON.stringify(response.responseJSON);
         }
 
         if ('response' in response) {

--- a/spec/fakeRequestSpec.js
+++ b/spec/fakeRequestSpec.js
@@ -752,6 +752,16 @@ describe('FakeRequest', function() {
     }
   });
 
+  it('stringifies responseJSON into responseText', function() {
+    var request = new this.FakeRequest();
+    request.open();
+    request.send();
+
+    request.respondWith({ status: 200, responseJSON: {'foo': 'bar'} });
+
+    expect(request.response).toEqual('{"foo":"bar"}');
+  });
+
   it('defaults the response attribute to the responseText', function() {
     var request = new this.FakeRequest();
     request.open();

--- a/src/fakeRequest.js
+++ b/src/fakeRequest.js
@@ -132,7 +132,7 @@ extend(FakeXMLHttpRequest, {
         if (this.readyState === 0) {
           throw new Error('DOMException: Failed to execute "setRequestHeader" on "XMLHttpRequest": The object\'s state must be OPENED.');
         }
-        
+
         if(this.requestHeaders.hasOwnProperty(header)) {
           this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
         } else {
@@ -280,6 +280,9 @@ extend(FakeXMLHttpRequest, {
         this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
         if (this.responseXML) {
           this.responseType = 'document';
+        }
+        if (response.responseJSON) {
+          this.responseText = JSON.stringify(response.responseJSON);
         }
 
         if ('response' in response) {


### PR DESCRIPTION
## Description
Resolves https://github.com/jasmine/jasmine-ajax/issues/177

`responseJSON` is basically just a shortcut that's not part of the [XHR spec](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), but is common in libraries such as [jquery.ajax](http://api.jquery.com/jquery.ajax/#data-types). While @slackersoft suggested also setting `this.responseType = 'json'`, I found this to actually be problematic because if the response is an object, jquery.ajax won't properly parse the response. It's expecting a string.

## How Has This Been Tested?
This shouldn't effect any other code, as property is optional and simply re-assigns the existing `responseText` property

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

