### PR TITLE
Fix link to 'Mocking ajax' page on main Jasmine site

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/jasmine/jasmine-ajax.png?branch=master)](https://travis-ci.org/jasmine/jasmine-ajax)
 [![Code Climate](https://codeclimate.com/github/jasmine/jasmine-ajax/badges/gpa.svg)](https://codeclimate.com/github/jasmine/jasmine-ajax)
 
-If you are using the updated version of this library, there is some additional documentation located at [jasmine.github.io](http://jasmine.github.io/edge/ajax.html) that is up-to-date.
+If you are using the updated version of this library, there is some additional documentation located at [jasmine.github.io](https://jasmine.github.io/tutorials/mocking_ajax) that is up-to-date.
 
 jasmine-ajax - Faking Ajax responses in your Jasmine suite.
 ============


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The existing link was dead; simply lead to a 404 page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's not that hard to find the "Mocking Ajax" link on the main Jasmine docs page. But, for someone who just came across `jasmine-ajax` and is excited to use it, it's a pretty jarring experience to be given a link that promises more up to date documentation, and have it be a dead link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by manually following the link on my branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have generated the `mock-ajax.js` file with `grunt build`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

