### PR TITLE
CI: Trust the Ruby 2.6 to have a fresh bundle, gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: bundler
 rvm: 2.6
 before_install:
   - npm install
-  - gem update --system
-  - gem install bundler
 addons:
   sauce_connect: true
 env:


### PR DESCRIPTION


## Description

Nowadays, the 2.6 distribution has a new RubyGems and Bundler.

This change skips 2 time-consuming extra steps.

## Motivation and Context

Clarity in the CI config.

Speed of execution of the CI builds.

## How Has This Been Tested?

By watching the CI output.

## Types of changes

A CI configuration change.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have generated the `mock-ajax.js` file with `grunt build`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

