### PR TITLE
feat: add support for asynchronous closures in withMock

### DIFF
--- a/spec/integration/mock-ajax-spec.js
+++ b/spec/integration/mock-ajax-spec.js
@@ -104,4 +104,15 @@ describe("mockAjax", function() {
     mockAjax.requests.reset();
     expect(mockAjax.requests.count()).toBe(0);
   });
+
+  it("supports asynchronous closures in withMock", async function() {
+    var fakeGlobal = { XMLHttpRequest: function() {} },
+        originalXHR = fakeGlobal.XMLHttpRequest,
+        mockAjax = new window.MockAjax(fakeGlobal);
+
+    await mockAjax.withMock(async function() {
+      expect(fakeGlobal.XMLHttpRequest).not.toBe(originalXHR);
+    });
+    expect(fakeGlobal.XMLHttpRequest).toBe(originalXHR);
+  });
 });

--- a/src/mockAjax.js
+++ b/src/mockAjax.js
@@ -34,9 +34,15 @@ getAjaxRequireObj().MockAjax = function($ajax) {
     this.withMock = function(closure) {
       this.install();
       try {
-        closure();
-      } finally {
+        var result = closure();
+        if (result && typeof result.then === 'function') {
+          return result.finally(() => this.uninstall());
+        }
         this.uninstall();
+        return result;
+      } catch (e) {
+        this.uninstall();
+        throw e;
       }
     };
 


### PR DESCRIPTION
1. Summary of changes
Enhanced the `withMock` method in `src/mockAjax.js` to detect returned promises and defer the `uninstall()` operation until the promise settles. Added a new integration test in `spec/integration/mock-ajax-spec.js` to verify proper handling of asynchronous closures.

2. Rationale
The previous implementation of `withMock` called `uninstall()` synchronously in a `finally` block, causing the mock to be torn down immediately after an asynchronous closure was invoked, before the Ajax request could complete. This change ensures that the mock remains installed until the asynchronous operation completes.

3. Technical impact
This change enables robust testing of asynchronous Ajax requests without modifying the existing API, maintaining backward compatibility for synchronous closures while adding critical support for modern asynchronous testing patterns. The implementation ensures consistent `uninstall()` behavior, including in cases where the closure throws an exception.